### PR TITLE
deck-build-log: don't hard code path to python

### DIFF
--- a/deck-build-log/deck-build-log-hot
+++ b/deck-build-log/deck-build-log-hot
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import collections

--- a/deck-build-log/deck-build-log-plot
+++ b/deck-build-log/deck-build-log-plot
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/deck-build-log/deck-metrics
+++ b/deck-build-log/deck-metrics
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import codecs


### PR DESCRIPTION
Python 2 and 3 aren't necessarily installed into /usr/bin.